### PR TITLE
Adjust the branch when using the use_merge_commit

### DIFF
--- a/src/pullRequests.ts
+++ b/src/pullRequests.ts
@@ -185,6 +185,13 @@ export default class PullRequests {
     try {
       let triggerParams: BuildkiteTriggerBuildParams;
 
+      // when using the merge commit of a PR, we need to fetch a special refspec
+      const trigger_branch = 
+      prConfig.use_merge_commit && pullRequest.mergeable && pullRequest.merge_commit_sha
+        ? `pull/${pullRequest.number.toString()}/merge`
+        : `${pullRequest.head.repo.owner.login}:${pullRequest.head.ref}`;
+      
+      
       if (prConfig.always_trigger_branch) {
         triggerParams = {
           branch: prConfig.always_trigger_branch,
@@ -193,7 +200,7 @@ export default class PullRequests {
         };
       } else {
         triggerParams = {
-          branch: `${pullRequest.head.repo.owner.login}:${pullRequest.head.ref}`,
+          branch: trigger_branch,
           commit: commitToBuild,
           pull_request_base_branch: targetBranch,
           pull_request_id: pullRequest.number,


### PR DESCRIPTION
When you use the use_merge_commit parameter, the triggered branch in BK should checkout the branch from the fork.
This is under the `/pull/{id}/merge` refspec and thus we need to use that branch name.


/cc @dliappis @roaksoax @pazone 