### PR TITLE
Fix Buildkite issue when check out merge commits

### DIFF
--- a/src/pullRequests.ts
+++ b/src/pullRequests.ts
@@ -133,7 +133,7 @@ export default class PullRequests {
 
     const commitToBuild =
       prConfig.use_merge_commit && pullRequest.mergeable && pullRequest.merge_commit_sha
-        ? pullRequest.merge_commit_sha
+        ? "HEAD"
         : pullRequest.head.sha;
 
     const labels = (pullRequest.labels || []).map((label) => label.name).join(',');


### PR DESCRIPTION
When you are checking out a merge commit and you provide the GitHub events merge commits, Buildkite kind of ignores the branch and tries to checkout the specific SHA ignoring that the Git ref Object that this sha belong to is not the pull/{id}/head but another one.

One solution to solve this would be that the default BK checkout out perform fetch on the `pull/{id}/*` so that the SHA will work regardless.